### PR TITLE
ipynb to pdf via latex export + yapf code formatting in cocalc

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,5 @@
+texlive-latex-base
+texlive-latex-recommended
+texlive-xetex
+dvipng
+ghostscript

--- a/apt.txt
+++ b/apt.txt
@@ -1,5 +1,9 @@
 texlive-latex-base
 texlive-latex-recommended
+texlive-generic-recommended
+texlive-science
+texlive-latex-extra
+texlive-fonts-recommended
 texlive-xetex
 dvipng
 ghostscript

--- a/environment.yml
+++ b/environment.yml
@@ -16,12 +16,7 @@ dependencies:
   - html5lib
   - beautifulsoup4
   - pytables
+  - yapf
   - pip
   - pip:
-    - modsimpy
-  
-  
-
-
-
-
+      - modsimpy


### PR DESCRIPTION
this adds a couple of latex related packages to make ipynb to pdf export via latex possible. I haven't tested this yet, but it is going in that direction.

The `yapf` package is just a small package to enable source code formatting on cocalc.