### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+jupyter
+numpy
+matplotlib
+seaborn
+pandas
+scipy
+pint
+sympy
+lxml
+html5lib
+beautifulsoup4
+tables
+yapf
+pip
+modsimpy


### PR DESCRIPTION
Add a pip `requirements.txt` file to allow non-Anaconda users to easily
configure their environment for the notebooks in this repo. This file
will tell pip to install the exact same packages as in the current
`environment.yml` file. It is worth noting that PyTables is `pytables`
in Anaconda but simply `tables` in PyPI.

This has been tested on Python 3.7.4 on a clean install of Debian
Buster, and is not guaranteed to work on all platforms. Specifically,
this does require tools such as GCC to be installed on your machine. One
other caveat is that the specific versions of the packages may not be
synchronized on PyPI and Anaconda, so future updates to these packages
may cause the environment install to break on one platform and not the
other.