### PR TITLE
Fix typo in cell

### DIFF
--- a/notebooks/chap12.ipynb
+++ b/notebooks/chap12.ipynb
@@ -746,7 +746,7 @@
     "    add_immunization(system, fraction)\n",
     "    add_hand_washing(system, spending)\n",
     "    \n",
-    "    results, run_simulation(system, update_func)\n",
+    "    results = run_simulation(system, update_func)\n",
     "    print(doses, system.init.S, system.beta, calc_total_infected(results))"
    ]
   },


### PR DESCRIPTION
This commit addresses a typo in the code that yields unexpected results.

In the cell, `results, run_simulation(...)` causes the simulation to be
run correctly, but the results are never assigned back to the original
`results` variable, meaning that the fraction of infected individuals is
never updated over the course of the sweep. When running this code, it
then seems like the fraction of infected individuals never changes,
regardless of the number of doses (and resulting changes in beta).