### PR TITLE
Fix Broken Book Zip Files Link

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -448,7 +448,7 @@ That should be everything you need.
 
 \section{Copying my files}
 
-The simplest way to get the files for this book is to download a Zip archive from \url{http://modsimpy.com/zip}.  You will need a program like WinZip or gzip to unpack the Zip file.  Make a note of the location of the files you unpack.
+The simplest way to get the files for this book is to download a Zip archive from \url{https://github.com/AllenDowney/ModSimPy/archive/master.zip}.  You will need a program like WinZip or gzip to unpack the Zip file.  Make a note of the location of the files you unpack.
 
 If you download the Zip file, you can skip the rest of this section, which explains how to use Git.
 


### PR DESCRIPTION
In Chapter 0, Section 0.6 - _Copying my files_, there is still reference to a broken link (http://modsimpy.com/zip). Probably the domain name itself is expired.
The best thing is to use the Github zip link itself (https://github.com/AllenDowney/ModSimPy/archive/master.zip), which is guaranteed to be working.