### PR TITLE
Update markdown for chapter 03 - Fix operator comparison table

### DIFF
--- a/chapters/chap03.ipynb
+++ b/chapters/chap03.ipynb
@@ -496,14 +496,14 @@
    "source": [
     "The equals operator is one of Python's *comparison operators*; the complete list is in the following table.\n",
     "\n",
-    "| Operation             \t| Symbol \t|\n",
-    "|-----------------------\t|--------\t|\n",
-    "| Less than             \t| `<`      \t|\n",
-    "| Greater than          \t| `>`      \t|\n",
-    "| Less than or equal    \t| `<=`     \t|\n",
-    "| Greater than or equal \t| `>=`     \t|\n",
-    "| Equal                 \t| `==`     \t|\n",
-    "| Not equal             \t| `!=`     \t|"
+    "| Operation             | Symbol |\n",
+    "|-----------------------|--------|\n",
+    "| Less than             | `<`    |\n",
+    "| Greater than          | `>`    |\n",
+    "| Less than or equal    | `<=`   |\n",
+    "| Greater than or equal | `>=`   |\n",
+    "| Equal                 | `==`   |\n",
+    "| Not equal             | `!=`   |"
    ]
   },
   {


### PR DESCRIPTION
The comparison of operators table includes "tab" character. These doesn't work well with Jupyter Notebook.

Before change:
![image](https://github.com/AllenDowney/ModSimPy/assets/5373426/e7b34482-5a53-4849-8827-24beb4df8e04)

After change:
![image](https://github.com/AllenDowney/ModSimPy/assets/5373426/fd3ac4d9-8b41-4210-8494-9fdd3349b246)
