### PR TITLE
Fix two small issues in a sentence about SymPy.

### DIFF
--- a/chapters/chap09.ipynb
+++ b/chapters/chap09.ipynb
@@ -904,7 +904,7 @@
     "tags": []
    },
    "source": [
-    "If you use SymPy to compute and expression, and then want to evaluate that expression in Python, SumPy provides a function called `pycode` that generates Python code:"
+    "If you use SymPy to compute an expression, and then want to evaluate that expression in Python, SymPy provides a function called `pycode` that generates Python code:"
    ]
   },
   {


### PR DESCRIPTION
One is a grammar fix for "and" to "an" and the other fixes a typo of SymPy as "SumPy". This sentence is only in the Jupyter notebook and not in the printed book.