### PR TITLE
Add newline between figure and its description to fix formatting

### DIFF
--- a/chapters/chap10.ipynb
+++ b/chapters/chap10.ipynb
@@ -321,6 +321,7 @@
     "\n",
     "![One queue, one server (left), one queue, two servers (middle), two\n",
     "queues, two servers (right).](https://github.com/AllenDowney/ModSim/raw/main/figs/queue.png)\n",
+    "\n",
     "*One queue, one server (left), one queue, two servers (middle), two\n",
     "queues, two servers (right).*\n",
     "\n",


### PR DESCRIPTION
The lack of a newline forces the "One queue, one server" figure's description to flow to the right of the figure. Adding a newline puts it directly under the figure.