### PR TITLE
Fix Colab interpretation of math symbols

### DIFF
--- a/chapters/chap11.ipynb
+++ b/chapters/chap11.ipynb
@@ -171,9 +171,7 @@
     "\n",
     "-   The number of recoveries we expect per day is $\\gamma i N$; dividing by $N$ yields the fraction of the population that recovers in a day, which is $\\gamma i$.\n",
     "\n",
-    "-   The number of new infections we expect per day is $\\beta s i N$;\n",
-    "    dividing by $N$ yields the fraction of the population that gets\n",
-    "    infected in a day, which is $\\beta s i$.\n",
+    "-   The number of new infections we expect per day is $\\beta s i N$; dividing by $N$ yields the fraction of the population that gets infected in a day, which is $\\beta s i$.\n",
     "\n",
     "The KM model assumes that the population is closed; that is, no one\n",
     "arrives or departs, so the size of the population, $N$, is constant."


### PR DESCRIPTION
The second summary bullet point starting with "The number of new infections we expect per day" was not rendering the math symbols correctly in Colab. Putting it all on the same line, like the first bullet point, fixes the issue. Github renders the page correctly without this change.