### PR TITLE
Add missing word to sentence

### DIFF
--- a/examples/glucose.ipynb
+++ b/examples/glucose.ipynb
@@ -337,7 +337,7 @@
     "Each time `error_func` is called, it prints the parameters, so we can get a sense of how `leastsq` works.\n",
     "\n",
     "`leastsq` has two return values.\n",
-    "The is an array with the best parameters:"
+    "The first is an array with the best parameters:"
    ]
   },
   {


### PR DESCRIPTION
Describing the return values of `leastsq` missed the word "first" in "The is an array with the best parameters".