### PR TITLE
Small grammar fix for draw_func

### DIFF
--- a/chapters/chap22.ipynb
+++ b/chapters/chap22.ipynb
@@ -979,7 +979,7 @@
    "id": "sustained-slide",
    "metadata": {},
    "source": [
-    "Inside the draw function, should use `decorate` to set the limits of the $x$ and $y$ axes.\n",
+    "Inside the draw function, you should use `decorate` to set the limits of the $x$ and $y$ axes.\n",
     "Otherwise `matplotlib` auto-scales the axes, which is usually not what you want.\n",
     "\n",
     "Now we can run the animation like this:\n",


### PR DESCRIPTION
Add "you" to "should use" when describing using `decorate` inside `draw_func.